### PR TITLE
Fixed bug of keeping old Sudoku

### DIFF
--- a/src/js/numpad.js
+++ b/src/js/numpad.js
@@ -2,6 +2,7 @@ import { draw_sudoku } from './draw_sudoku.js'
 import { mark_cell, set_cell } from './script.js'
 import { check_board, Sudoku } from './sudoku.js'
 import { show_hint } from './check-hint.js'
+import { state } from './state.js'
 
 /**
  * Creates a numpad and inserts it into the HTMl document.
@@ -56,45 +57,45 @@ export function createNumpad(sudoku) {
         if (event.target.tagName !== 'BUTTON') return
         const numpadValue = event.target.textContent
         if (
-            sudoku.marked_cell != null &&
+            state.sudoku.marked_cell != null &&
             numpadValue !== 'Check board' &&
             numpadValue !== 'Show hint'
         ) {
-            let cell = sudoku.marked_cell
-            mark_cell(sudoku, null)
+            let cell = state.sudoku.marked_cell
+            mark_cell(state.sudoku, null)
             if (numpadValue === 'DEL') {
-                set_cell(sudoku, cell[0], cell[1], null)
+                set_cell(state.sudoku, cell[0], cell[1], null)
             } else {
-                set_cell(sudoku, cell[0], cell[1], numpadValue)
+                set_cell(state.sudoku, cell[0], cell[1], numpadValue)
             }
         }
         if (numpadValue == 'Check board') {
             console.log('Checking board')
-            check_board(sudoku)
+            check_board(state.sudoku)
         }
         if (numpadValue == 'Show hint') {
             console.log('Show hints')
-            show_hint(sudoku)
+            show_hint(state.sudoku)
         }
-        draw_sudoku(sudoku)
+        draw_sudoku(state.sudoku)
     }
 
     document.addEventListener('keydown', function (event) {
         console.log(`GOT INPUT: ${event.key}`)
-        if (sudoku.marked_cell != null) {
+        if (state.sudoku.marked_cell != null) {
             if (event.key === 'Delete' || event.key === 'Backspace') {
-                let cell = sudoku.marked_cell
-                mark_cell(sudoku, null)
-                set_cell(sudoku, cell[0], cell[1], null)
+                let cell = state.sudoku.marked_cell
+                mark_cell(state.sudoku, null)
+                set_cell(state.sudoku, cell[0], cell[1], null)
             } else {
                 let num = Number.parseInt(event.key)
-                if (isNaN(num) || num == 0 || num > sudoku.size) return
+                if (isNaN(num) || num == 0 || num > state.sudoku.size) return
 
-                let cell = sudoku.marked_cell
-                mark_cell(sudoku, null)
-                set_cell(sudoku, cell[0], cell[1], event.key)
+                let cell = state.sudoku.marked_cell
+                mark_cell(state.sudoku, null)
+                set_cell(state.sudoku, cell[0], cell[1], event.key)
             }
         }
-        draw_sudoku(sudoku)
+        draw_sudoku(state.sudoku)
     })
 }

--- a/src/js/switch_button.js
+++ b/src/js/switch_button.js
@@ -29,7 +29,7 @@ function createSwitchButton() {
 
 function toggleCandidate(cell, num) {
     if (cell.candidates.includes(num)) {
-        cell.candidates = cell.candidates.filter(n => n !== num)
+        cell.candidates = cell.candidates.filter((n) => n !== num)
     } else {
         cell.num = null
         cell.candidates.push(num)
@@ -37,60 +37,68 @@ function toggleCandidate(cell, num) {
     }
 }
 
-document.addEventListener('keydown', (event) => {
-    if (!noteMode) return
-    if (!state.sudoku || !state.sudoku.marked_cell) return
+document.addEventListener(
+    'keydown',
+    (event) => {
+        if (!noteMode) return
+        if (!state.sudoku || !state.sudoku.marked_cell) return
 
-    const [r, c] = state.sudoku.marked_cell
-    const cell = state.sudoku.grid[r][c]
-    if (cell.is_hint) return
+        const [r, c] = state.sudoku.marked_cell
+        const cell = state.sudoku.grid[r][c]
+        if (cell.is_hint) return
 
-    if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (event.key === 'Delete' || event.key === 'Backspace') {
+            event.stopImmediatePropagation()
+            cell.candidates = []
+            draw_sudoku(state.sudoku)
+            updateState(state)
+            return
+        }
+
+        const num = Number.parseInt(event.key)
+        if (isNaN(num) || num < 1 || num > state.sudoku.size) return
+
         event.stopImmediatePropagation()
-        cell.candidates = []
+        toggleCandidate(cell, num)
         draw_sudoku(state.sudoku)
         updateState(state)
-        return
-    }
+    },
+    true
+)
 
-    const num = Number.parseInt(event.key)
-    if (isNaN(num) || num < 1 || num > state.sudoku.size) return
+document.addEventListener(
+    'click',
+    (event) => {
+        if (!noteMode) return
+        if (!event.target.closest('#sudoku-numpad')) return
+        if (event.target.tagName !== 'BUTTON') return
+        if (!state.sudoku || !state.sudoku.marked_cell) return
 
-    event.stopImmediatePropagation()
-    toggleCandidate(cell, num)
-    draw_sudoku(state.sudoku)
-    updateState(state)
-}, true)
+        const value = event.target.textContent
 
-document.addEventListener('click', (event) => {
-    if (!noteMode) return
-    if (!event.target.closest('#sudoku-numpad')) return
-    if (event.target.tagName !== 'BUTTON') return
-    if (!state.sudoku || !state.sudoku.marked_cell) return
+        if (value === 'Check board' || value === 'Show hint') return
 
-    const value = event.target.textContent
+        const [r, c] = state.sudoku.marked_cell
+        const cell = state.sudoku.grid[r][c]
+        if (cell.is_hint) return
 
-    if (value === 'Check board' || value === 'Show hint') return
+        event.stopImmediatePropagation()
 
-    const [r, c] = state.sudoku.marked_cell
-    const cell = state.sudoku.grid[r][c]
-    if (cell.is_hint) return
-
-    event.stopImmediatePropagation()
-
-    if (value === 'DEL') {
-        cell.candidates = []
-        cell.num = null
-    } else {
-        const num = Number.parseInt(value)
-        if (!isNaN(num) && num >= 1 && num <= state.sudoku.size) {
-            toggleCandidate(cell, num)
+        if (value === 'DEL') {
+            cell.candidates = []
+            cell.num = null
+        } else {
+            const num = Number.parseInt(value)
+            if (!isNaN(num) && num >= 1 && num <= state.sudoku.size) {
+                toggleCandidate(cell, num)
+            }
         }
-    }
 
-    draw_sudoku(state.sudoku)
-    updateState(state)
-}, true)
+        draw_sudoku(state.sudoku)
+        updateState(state)
+    },
+    true
+)
 
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', createSwitchButton)


### PR DESCRIPTION
The numpad event listeners used the Sudoku instance that the createNumpad function got as a parameter.
This means that it kept the old sudoku instance, even when a new one was made.